### PR TITLE
support multiple accounts using --account

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,38 @@ Run:
 ```
 ec2-instance-lister
 ```
+
+## options
+
+### --searchString | -s
+Specify a search string to find in the instance tags
+
+### --account
+Specify an account name for different credentials.
+The default credentials are named _aws_ and they appear in the config file like so:
+
+```
+{
+    "aws": {
+        "accessKeyId": "blablabla",
+        "secretAccessKey": "shhhhhhhhh",
+        "region": "us-moon-1"
+    }
+}
+```
+
+if you specify --account or add it in the config, e.g. ```ec2-instance-lister --account=foo``` then credentials used will be under the account name key:
+
+```
+{
+    "aws": { ... },
+    "foo": {
+        "accessKeyId": "blablabla",
+        "secretAccessKey": "shhhhhhhhh",
+        "region": "us-moon-1"  
+    }
+}
+```
+
+### --listPrivateInstances
+A flag that indicates if results should include private instances (that only has private ips, inside a vpc for example). Defaults to false

--- a/README.md
+++ b/README.md
@@ -54,3 +54,4 @@ if you specify --account or add it in the config, e.g. ```ec2-instance-lister --
 
 ### --ipType
 which ip of the server to return: private or public, defaults to 'public'
+when selecting public or private, instances that do not have a particular ip will not be listed

--- a/README.md
+++ b/README.md
@@ -52,5 +52,5 @@ if you specify --account or add it in the config, e.g. ```ec2-instance-lister --
 }
 ```
 
-### --listPrivateInstances
-A flag that indicates if results should include private instances (that only has private ips, inside a vpc for example). Defaults to false
+### --ipType
+which ip of the server to return: private or public, defaults to 'public'

--- a/index.js
+++ b/index.js
@@ -20,7 +20,17 @@ var ec2params = {
 	}]
 };
 
-var ec2 = new AWS.EC2(config.aws);
+var credentials = config.aws
+
+if (config.account) {
+	if (config[config.account]) {
+		credentials = config[config.account]
+	} else {
+		return console.error('you specified an account %s, but the config did not include actual credential data, try adding config.[account name] = { ... credentials here ...}', config.account)
+	}
+}
+
+var ec2 = new AWS.EC2(credentials);
 ec2.describeInstances(ec2params, onResponse);
 
 function onResponse(err, data) {

--- a/index.js
+++ b/index.js
@@ -9,15 +9,15 @@ var tagValue;
 if (config.s) {
 	tagValue = config.s;
 } else if (config.tag || config.t) {
-	config.tag = config.tag || config.t
-	var split = config.tag.split('=')
+	config.tag = config.tag || config.t;
+	var split = config.tag.split('=');
 	
 	if (split.length !== 2) {
-		throw new Error('invalid tag expression, must be key=value. Input was ' + config.tag)
+		throw new Error('invalid tag expression, must be key=value. Input was ' + config.tag);
 	}
 
-	tagName = split[0].toLowerCase()
-	tagValue = split[1]
+	tagName = split[0].toLowerCase();
+	tagValue = split[1];
 } else {
 	tagValue = config.searchString;
 }
@@ -35,13 +35,13 @@ var credentials = config.aws
 
 if (config.account) {
 	if (config[config.account]) {
-		credentials = config[config.account]
+		credentials = config[config.account];
 	} else {
-		return console.error('you specified an account %s, but the config did not include actual credential data, try adding config.[account name] = { ... credentials here ...}', config.account)
+		return console.error('you specified an account %s, but the config did not include actual credential data, try adding config.[account name] = { ... credentials here ...}', config.account);
 	}
 }
 
-var ipField = config.ipType === 'private' ? 'PrivateIpAddress' : 'PublicIpAddress'
+var ipField = config.ipType === 'private' ? 'PrivateIpAddress' : 'PublicIpAddress';
 
 var ec2 = new AWS.EC2(credentials);
 ec2.describeInstances(ec2params, onResponse);
@@ -60,7 +60,7 @@ function onResponse(err, data) {
 
 	var result = [];
 	
-	console.error('NOTE: only ips are written to stdout, the rest is written to stderr.')
+	console.error('NOTE: only ips are written to stdout, the rest is written to stderr.');
 
 	for (var i = 0; i < res.length; i++) {
 		var group = res[i].Instances;
@@ -70,9 +70,9 @@ function onResponse(err, data) {
 				var tags = instance.Tags;
 				for (var k = 0; k < tags.length; k++) {
 					if ((tags[k].Key.toLowerCase() === tagName) && (tags[k].Value.indexOf(tagValue) > -1)) {
-						var ip = instance[ipField]
+						var ip = instance[ipField];
 						if (ip) {
-							console.error('instance id [%s]', instance.InstanceId)
+							console.error('instance id [%s]', instance.InstanceId);
 							console.log(ip);
 						}
 					}

--- a/index.js
+++ b/index.js
@@ -30,6 +30,8 @@ if (config.account) {
 	}
 }
 
+var listPrivateInstances = typeof(config.listPrivateInstances) === 'boolean' ? config.listPrivateInstances : false
+
 var ec2 = new AWS.EC2(credentials);
 ec2.describeInstances(ec2params, onResponse);
 
@@ -55,7 +57,11 @@ function onResponse(err, data) {
 				var tags = instance.Tags;
 				for (var k = 0; k < tags.length; k++) {
 					if ((tags[k].Key === 'Name') && (tags[k].Value.indexOf(searchString) > -1)) {
-						console.log(instance.PublicIpAddress);
+						if (instance.PublicIpAddress) {
+							console.log(instance.PublicIpAddress);
+						} else if (listPrivateInstances) {
+							console.log(instance.PrivateIpAddress);
+						}
 					}
 				}
 			}

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ if (config.account) {
 	}
 }
 
-var listPrivateInstances = typeof(config.listPrivateInstances) === 'boolean' ? config.listPrivateInstances : false
+var ipField = config.ipType === 'private' ? 'PrivateIpAddress' : 'PublicIpAddress'
 
 var ec2 = new AWS.EC2(credentials);
 ec2.describeInstances(ec2params, onResponse);
@@ -57,10 +57,9 @@ function onResponse(err, data) {
 				var tags = instance.Tags;
 				for (var k = 0; k < tags.length; k++) {
 					if ((tags[k].Key === 'Name') && (tags[k].Value.indexOf(searchString) > -1)) {
-						if (instance.PublicIpAddress) {
-							console.log(instance.PublicIpAddress);
-						} else if (listPrivateInstances) {
-							console.log(instance.PrivateIpAddress);
+						var ip = instance[ipField]
+						if (ip) {
+							console.log(ip);
 						}
 					}
 				}

--- a/index.js
+++ b/index.js
@@ -3,12 +3,23 @@
 var AWS = require('aws-sdk');
 var rc = require('rc');
 var config = rc('ec2-instance-lister');
-var searchString;
+var tagName = 'name';
+var tagValue;
 
 if (config.s) {
-	searchString = config.s;
+	tagValue = config.s;
+} else if (config.tag || config.t) {
+	config.tag = config.tag || config.t
+	var split = config.tag.split('=')
+	
+	if (split.length !== 2) {
+		throw new Error('invalid tag expression, must be key=value. Input was ' + config.tag)
+	}
+
+	tagName = split[0].toLowerCase()
+	tagValue = split[1]
 } else {
-	searchString = config.searchString;
+	tagValue = config.searchString;
 }
 
 var ec2params = {
@@ -48,6 +59,8 @@ function onResponse(err, data) {
 	}
 
 	var result = [];
+	
+	console.error('NOTE: only ips are written to stdout, the rest is written to stderr.')
 
 	for (var i = 0; i < res.length; i++) {
 		var group = res[i].Instances;
@@ -56,9 +69,10 @@ function onResponse(err, data) {
 				var instance = group[j];
 				var tags = instance.Tags;
 				for (var k = 0; k < tags.length; k++) {
-					if ((tags[k].Key === 'Name') && (tags[k].Value.indexOf(searchString) > -1)) {
+					if ((tags[k].Key.toLowerCase() === tagName) && (tags[k].Value.indexOf(tagValue) > -1)) {
 						var ip = instance[ipField]
 						if (ip) {
+							console.error('instance id [%s]', instance.InstanceId)
 							console.log(ip);
 						}
 					}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ec2-instance-lister",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "description": "List IP addresses of ec2 instances having a certain keyword in their name",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
the default account will remain "aws", thus its fully backwards compatible.

one may invoke the cli tool with --account to direct it to a different set of credentials, then config file will look like so:

```
{
   aws: {... default (access key, secret, etc)...},
   myAccount: { ...another access key, secret, region ...}
}
```

then do:

```
ec2-instance-lister --account=myAccount --searchString=someTagData
```

or

```
ec2l --account=123 -s=string
```
